### PR TITLE
Handle employee list responses for structure employees

### DIFF
--- a/app/src/main/java/com/bancusoft/statdataexplorer/network/RestApi.java
+++ b/app/src/main/java/com/bancusoft/statdataexplorer/network/RestApi.java
@@ -1,6 +1,6 @@
 package com.bancusoft.statdataexplorer.network;
 
-import com.bancusoft.statdataexplorer.models.EmployeesApiResponse;
+import com.bancusoft.statdataexplorer.models.EmployeeModel;
 import com.bancusoft.statdataexplorer.models.ResponseModel;
 import com.bancusoft.statdataexplorer.models.ResponseModelEmployee;
 import com.bancusoft.statdataexplorer.models.StarResponseModel;
@@ -25,7 +25,7 @@ public interface RestApi {
     Call<List<StructBns>> getStructBns();
 
     @GET("index.php?action=GET_EMPLOYEES_BY_STRUCT")
-    Call<EmployeesApiResponse> getEmployeesByStruct(
+    Call<List<EmployeeModel>> getEmployeesByStruct(
             @Query("type") String type,
             @Query("name") String name
     );


### PR DESCRIPTION
## Summary
- Expect a list of employees from `getEmployeesByStruct`
- Load employees directly from the list and log unexpected responses

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975c87da448332b84abccb4e6382ee