### PR TITLE
Sort employee lists before updating adapters

### DIFF
--- a/app/src/main/java/com/bancusoft/statdataexplorer/activities/EmployeesByStructActivity.java
+++ b/app/src/main/java/com/bancusoft/statdataexplorer/activities/EmployeesByStructActivity.java
@@ -17,6 +17,8 @@ import com.bancusoft.statdataexplorer.network.ApiUtils;
 import com.bancusoft.statdataexplorer.network.RestApi;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import com.google.gson.JsonSyntaxException;
 
@@ -83,6 +85,7 @@ public class EmployeesByStructActivity extends AppCompatActivity {
                     List<EmployeeModel> result = response.body();
                     if (result != null) {
                         if (!result.isEmpty()) {
+                            Collections.sort(result, Comparator.comparing(EmployeeModel::getName, String.CASE_INSENSITIVE_ORDER));
                             adapter.updateData(result);
                         } else {
                             Toast.makeText(EmployeesByStructActivity.this, "Nu s-au găsit angajați!", Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/bancusoft/statdataexplorer/activities/EmployeesListActivity.java
+++ b/app/src/main/java/com/bancusoft/statdataexplorer/activities/EmployeesListActivity.java
@@ -18,6 +18,8 @@ import com.bancusoft.statdataexplorer.network.ApiUtils;
 import com.bancusoft.statdataexplorer.network.RestApi;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import retrofit2.Call;
@@ -78,6 +80,8 @@ public class EmployeesListActivity extends AppCompatActivity {
             public void onResponse(Call<ResponseModelEmployee> call, Response<ResponseModelEmployee> response) {
                 if (response.isSuccessful() && response.body() != null) {
                     allEmployees = response.body().getResult();
+                    if (allEmployees == null) allEmployees = new ArrayList<>();
+                    Collections.sort(allEmployees, Comparator.comparing(EmployeeModel::getName, String.CASE_INSENSITIVE_ORDER));
                     adapter = new EmployeeAdapter(EmployeesListActivity.this, allEmployees);
                     recyclerView.setAdapter(adapter);
                 } else {
@@ -103,6 +107,7 @@ public class EmployeesListActivity extends AppCompatActivity {
                         if (response.isSuccessful() && response.body() != null) {
                             List<EmployeeModel> list = response.body().getResult();
                             if (list == null) list = new ArrayList<>();
+                            Collections.sort(list, Comparator.comparing(EmployeeModel::getName, String.CASE_INSENSITIVE_ORDER));
                             adapter = new EmployeeAdapter(EmployeesListActivity.this, list);
                             recyclerView.setAdapter(adapter);
                         }


### PR DESCRIPTION
## Summary
- Sort employees by name (case-insensitive) before updating adapters in EmployeesByStructActivity
- Sort fetched employee lists before adapter creation in EmployeesListActivity for general and star-filtered queries

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a01de1b6c8332a4259245b90cd19b