### PR TITLE
Improve spacing for employees-by-struct screen

### DIFF
--- a/app/src/main/res/layout/activity_employees_by_struct.xml
+++ b/app/src/main/res/layout/activity_employees_by_struct.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/white"
-    android:padding="@dimen/default_spacing">
+    android:padding="@dimen/large_spacing">
 
     <androidx.appcompat.widget.SearchView
         android:id="@+id/searchViewEmployees"
@@ -16,7 +16,7 @@
         android:id="@+id/recyclerViewEmployees"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/default_spacing"
+        android:layout_marginTop="@dimen/large_spacing"
         android:scrollbars="vertical" />
 
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,3 +1,4 @@
 <resources>
     <dimen name="default_spacing">12dp</dimen>
+    <dimen name="large_spacing">24dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- expand layout padding and list margin in employees-by-struct screen for easier tapping
- add shared dimension for larger spacing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b50d441dc833286f51776b8f400e1