### PR TITLE
Increase spacing and make email clickable

### DIFF
--- a/app/src/main/java/com/bancusoft/statdataexplorer/adapters/EmployeeAdapter.java
+++ b/app/src/main/java/com/bancusoft/statdataexplorer/adapters/EmployeeAdapter.java
@@ -2,6 +2,7 @@ package com.bancusoft.statdataexplorer.adapters;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,6 +13,7 @@ import android.text.SpannableString;
 import android.text.style.ForegroundColorSpan;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bancusoft.statdataexplorer.R;
@@ -54,6 +56,12 @@ public class EmployeeAdapter extends RecyclerView.Adapter<EmployeeAdapter.ViewHo
         holder.txtPhone.setText(e.getPhone());
         holder.txtPhoneInternal.setText(e.getPhoneinternal());
         holder.txtEmail.setText(e.getEmail());
+        holder.txtEmail.setTextColor(ContextCompat.getColor(context, R.color.link_blue));
+        holder.txtEmail.setOnClickListener(v -> {
+            Intent emailIntent = new Intent(Intent.ACTION_SENDTO);
+            emailIntent.setData(Uri.parse("mailto:" + e.getEmail()));
+            context.startActivity(emailIntent);
+        });
         holder.txtPersonalInfo.setText(e.getPersonalinfo());
         holder.txtFormName.setText(e.getFormname());
         holder.txtPhoneMobil.setText(getHighlightedText(e.getPhonemobil(), searchQuery, Color.CYAN));

--- a/app/src/main/res/layout/activity_employees_by_struct.xml
+++ b/app/src/main/res/layout/activity_employees_by_struct.xml
@@ -16,7 +16,7 @@
         android:id="@+id/recyclerViewEmployees"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/large_spacing"
+        android:layout_marginTop="@dimen/extra_large_spacing"
         android:scrollbars="vertical" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_employee.xml
+++ b/app/src/main/res/layout/item_employee.xml
@@ -20,7 +20,14 @@
         <TextView android:id="@+id/txtDepart" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Departament" />
         <TextView android:id="@+id/txtPhone" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Telefon" />
         <TextView android:id="@+id/txtPhoneInternal" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Telefon Intern" />
-        <TextView android:id="@+id/txtEmail" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Email" />
+        <TextView
+            android:id="@+id/txtEmail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Email"
+            android:textColor="@color/link_blue"
+            android:autoLink="email"
+            android:linksClickable="true" />
         <TextView android:id="@+id/txtPersonalInfo" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Info Personal" />
         <TextView android:id="@+id/txtFormName" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Formular" />
         <TextView android:id="@+id/txtPhoneMobil" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Telefon Mobil" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -41,4 +41,5 @@
     <color name="color_9">#3F51B5</color>
     <color name="color_10">#673AB7</color>
     <color name="color_11">#757575</color>
+    <color name="link_blue">#4FC3F7</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,5 @@
 <resources>
     <dimen name="default_spacing">12dp</dimen>
     <dimen name="large_spacing">24dp</dimen>
+    <dimen name="extra_large_spacing">32dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- enlarge RecyclerView margin in employees-by-structure screen using new `extra_large_spacing` dimension
- render employee email in light-blue link style and open email app on tap
- define `link_blue` color for reusable link styling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b55829b8483328b3ed9eb8f200db9