### PR TITLE
Add toolbar to EmployeesByStruct screen

### DIFF
--- a/app/src/main/java/com/bancusoft/statdataexplorer/activities/EmployeesByStructActivity.java
+++ b/app/src/main/java/com/bancusoft/statdataexplorer/activities/EmployeesByStructActivity.java
@@ -35,6 +35,7 @@ public class EmployeesByStructActivity extends BaseEmployeesActivity {
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_employees_by_struct);
+        setSupportActionBar(findViewById(R.id.toolbarEmployeesByStruct));
 
         type = getIntent().getStringExtra("type");
         name = getIntent().getStringExtra("name");

--- a/app/src/main/res/layout/activity_employees_by_struct.xml
+++ b/app/src/main/res/layout/activity_employees_by_struct.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/white"
     android:padding="@dimen/large_spacing">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbarEmployeesByStruct"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:titleTextColor="@android:color/white" />
 
     <androidx.appcompat.widget.SearchView
         android:id="@+id/searchViewEmployees"


### PR DESCRIPTION
## Summary
- Add MaterialToolbar to employees-by-structure layout and style it
- Register the toolbar as the activity's app bar so menu items display

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5ca846708332abd493775afa0744