### PR TITLE
Enable clickable contact fields in employee layouts

### DIFF
--- a/app/src/main/res/layout/activity_employee_details.xml
+++ b/app/src/main/res/layout/activity_employee_details.xml
@@ -67,6 +67,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Telefon"
+            android:textColor="@color/link_blue"
+            android:autoLink="phone"
+            android:linksClickable="true"
             android:paddingVertical="8dp"
             android:layout_marginTop="8dp" />
 
@@ -91,6 +94,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Email"
+            android:textColor="@color/link_blue"
             android:autoLink="email"
             android:linksClickable="true"
             android:paddingVertical="8dp"

--- a/app/src/main/res/layout/item_employee.xml
+++ b/app/src/main/res/layout/item_employee.xml
@@ -22,7 +22,11 @@
             android:id="@+id/txtPhone"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Telefon" />
+            android:text="Telefon"
+            android:textColor="@color/link_blue"
+            android:autoLink="phone"
+            android:linksClickable="true"
+            android:layout_marginTop="8dp" />
         <TextView
             android:id="@+id/txtPhoneInternal"
             android:layout_width="wrap_content"
@@ -35,7 +39,8 @@
             android:text="Email"
             android:textColor="@color/link_blue"
             android:autoLink="email"
-            android:linksClickable="true" />
+            android:linksClickable="true"
+            android:layout_marginTop="8dp" />
         <TextView android:id="@+id/txtPersonalInfo" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Info Personal" />
         <TextView android:id="@+id/txtFormName" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Formular" />
         <TextView
@@ -45,7 +50,8 @@
             android:text="Telefon Mobil"
             android:textColor="@color/link_blue"
             android:autoLink="phone"
-            android:linksClickable="true" />
+            android:linksClickable="true"
+            android:layout_marginTop="8dp" />
         <TextView android:id="@+id/txtFloor" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Etaj" />
         <TextView android:id="@+id/txtOffice" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Birou" />
         <TextView android:id="@+id/txtNotice" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Notă" />


### PR DESCRIPTION
## Summary
- Make office phone and email fields clickable in employee details
- Linkify contact info and add top margin for readability in employee list items

## Testing
- `bash gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c945da52c833292716e44303564f0